### PR TITLE
Fix README for issuing tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Here is the application software architecture work-flow:
       
 - Run the scripts to issue tokens
 
-      truffle exec scripts/issue-tokens.js
+      truffle exec scripts/issue-token.js
 
 Demo of the DApp with the screenshots can be found on [this wiki page](https://github.com/ahmetozlu/defi_yield_farming/wiki/Demo-of-the-DApp).
 


### PR DESCRIPTION
scripts/issue-tokens.js doesn't exist.  
Should it be renamed in the scripts folder?

See #6 